### PR TITLE
Implement first couple commands

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,6 +13,7 @@ ignore = {
 }
 
 globals = {
+  zk_util
 }
 
 -- Global objects defined by the C code

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,7 +13,8 @@ ignore = {
 }
 
 globals = {
-  zk_util
+  zk_util,
+  zk_utils
 }
 
 -- Global objects defined by the C code

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ user-interface elements around the fantastic golang library,
 
 
 ```lua
-require("zk").init({})
+require("zk").setup({})
 ```
 
 #### Default config

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ interface elements around `zk`.
 
 ### Install
 
-#### paq.nvim
+#### paq-nvim
 
-`paq { "megalithic/zk.nvim", opt = true }`
+`paq { "megalithic/zk.nvim" }`
 
 #### packer.nvim
 
-`use { "megalithic/zk.nvim", opt = true }`
+`use { "megalithic/zk.nvim" }`
 
 #### vim-plug
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The primary goals of this plugin are to provide handy maps, commands, and
 interface elements around `zk`. 
 
 
-### Install
+## Install
 
 #### paq-nvim
 
@@ -20,10 +20,31 @@ interface elements around `zk`.
 
 `Plug "megalithic/zk.nvim"`
 
-### Configuration
 
-TBD
+## Configuration
 
+- TBD
+
+
+## Usage
+
+
+#### Install `zk`
+
+Install the `zk` binary (as long as `go` is installed in your system's `PATH`).
+
+```viml
+:ZkInstall
+```
+
+
+#### Create a new note
+
+Create a new `zk` note, with an optional title string.
+
+```viml
+:ZkNew Optional Title
+```
 
 ### Credit
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # zk.nvim
 
-A lightweight neovim (lua-based) wrapper around https://github.com/mickael-menu/zk
+A lightweight neovim (lua-based) wrapper around [`zk`](https://github.com/mickael-menu/zk).
 
 The primary goals of this plugin are to provide handy maps, commands, and
-interface elements around `zk`. 
+user-interface elements around the fantastic golang library,
+[`zk`](https://github.com/mickael-menu/zk).
 
 
 ## Install
@@ -23,7 +24,20 @@ interface elements around `zk`.
 
 ## Configuration
 
-- TBD
+
+```lua
+require("zk").init({})
+```
+
+#### Default config
+
+```lua
+{
+  debug = false,
+  root_target = ".zk",
+  default_notebook_path = ""
+}
+```
 
 
 ## Usage

--- a/autoload/zk.vim
+++ b/autoload/zk.vim
@@ -1,1 +1,0 @@
-call v:lua.require('zk').init()

--- a/autoload/zk.vim
+++ b/autoload/zk.vim
@@ -1,0 +1,1 @@
+call v:lua.require('zk').init()

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -3,9 +3,17 @@
 local adapter = {}
 
 function adapter.new()
+  zk_util.command {
+    "ZkNew",
+    function()
+    end
+  }
+  vim.api.nvim_set_keymap("n", "<leader>zn", "<cmd>ZkNew<CR>", {noremap = true, silent = false, expr = false})
 end
+
 function adapter.search()
 end
+
 function adapter.backlink()
 end
 

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -1,4 +1,4 @@
--- The interface between our plugin and zk
+-- The interface between zk.nvim and zk
 
 local M = {}
 
@@ -6,7 +6,7 @@ function M.new(title)
   local cmd = "zk new"
 
   if title ~= nil and title ~= "" then
-    cmd = string.format("zk new --title %s", title)
+    cmd = string.format("zk new --print-path --title %s", title)
   end
 
   vim.fn.jobstart(
@@ -17,7 +17,11 @@ function M.new(title)
           string.format("[zk.nvim] on_stdout -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
         )
 
-        vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+        vim.api.nvim_out_write("[zk.nvim] new note created: " .. d[1])
+
+        -- FIXME: defaulting to opening in a new vsplit for now..
+        vim.cmd(string.format("vnew %s", d[1]))
+
         return
       end,
       on_stderr = function(j, d, e)
@@ -26,27 +30,30 @@ function M.new(title)
         )
 
         if d == 0 then
-          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+          vim.api.nvim_out_write("[zk.nvim] new note created")
           return
         end
 
-        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note -> " .. d[1])
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new note -> " .. d[1])
       end,
       on_exit = function(j, d, e)
         print(string.format("[zk.nvim] on_exit -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e)))
 
         if d == 0 then
-          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+          vim.api.nvim_out_write("[zk.nvim] new note created")
           return
         end
 
-        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new note")
       end
     }
   )
 end
 
 function M.search()
+end
+
+function M.create_link()
 end
 
 function M.backlink()

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -2,12 +2,24 @@
 
 local M = {}
 
-function M.new(args)
-  -- if args.title == nil then
-  --   vim.fn.system(string.format("zk new --title %s %s", args.title, args.content))
-  -- else
-  --   vim.fn.system(string.format("zk new --title %s %s", args.title, args.content))
-  -- end
+function M.new(title)
+  local cmd = "zk new"
+
+  if title ~= nil and title ~= "" then
+    cmd = string.format("zk new --title %s", title)
+  end
+
+  vim.fn.jobstart(cmd, {
+    on_exit = function(j, d, e)
+    print(string.format("[zk.nvim] on_job_exit -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e)))
+      if d == 0 then
+        vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+        return
+      end
+
+      vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+    end,
+  })
 end
 
 function M.search()

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -9,17 +9,42 @@ function M.new(title)
     cmd = string.format("zk new --title %s", title)
   end
 
-  vim.fn.jobstart(cmd, {
-    on_exit = function(j, d, e)
-    print(string.format("[zk.nvim] on_job_exit -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e)))
-      if d == 0 then
-        vim.api.nvim_out_write("[zk.nvim] new zettel note created")
-        return
-      end
+  vim.fn.jobstart(
+    cmd,
+    {
+      on_stdout = function(j, d, e)
+        print(
+          string.format("[zk.nvim] on_stdout -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
+        )
+        if d == 0 then
+          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+          return
+        end
 
-      vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
-    end,
-  })
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+      end,
+      on_stderr = function(j, d, e)
+        print(
+          string.format("[zk.nvim] on_stderr -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
+        )
+        if d == 0 then
+          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+          return
+        end
+
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+      end,
+      on_exit = function(j, d, e)
+        print(string.format("[zk.nvim] on_exit -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e)))
+        if d == 0 then
+          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+          return
+        end
+
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+      end
+    }
+  )
 end
 
 function M.search()

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -3,12 +3,19 @@
 local adapter = {}
 
 function adapter.new()
-  zk_util.command {
-    "ZkNew",
-    function()
-    end
-  }
-  vim.api.nvim_set_keymap("n", "<leader>zn", "<cmd>ZkNew<CR>", {noremap = true, silent = false, expr = false})
+  -- zk_util.command {
+  --   "ZkNew",
+  --   function()
+  --   end
+  -- }
+  zk_util.command {"ZkNew", [[<cmd>!zk new --title <q-args>]], nargs = 1}
+  local title = vim.fn.input("Enter new Zk note title: ")
+  if title and #title > 0 then
+    vim.cmd "redraw" -- clear the input message we just added
+    vim.cmd(string.format([[execute 'ZkNew %s']], title))
+  end
+  vim.cmd([[execute 'ZkNew']], title)
+  -- vim.api.nvim_set_keymap("n", "<leader>zn", "<cmd>ZkNew<CR>", {noremap = true, silent = false, expr = true})
 end
 
 function adapter.search()

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -17,10 +17,12 @@ function M.new(title)
           string.format("[zk.nvim] on_stdout -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
         )
 
-        vim.api.nvim_out_write("[zk.nvim] new note created: " .. d[1])
+        if d[1] ~= nil and d[1] ~= "" then
+          vim.api.nvim_out_write("[zk.nvim] new note created: " .. d[1])
 
-        -- FIXME: defaulting to opening in a new vsplit for now..
-        vim.cmd(string.format("vnew %s", d[1]))
+          -- FIXME: defaulting to opening in a new vsplit for now..
+          vim.cmd(string.format("vnew %s", d[1]))
+        end
 
         return
       end,

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -1,27 +1,19 @@
 -- The interface between our plugin and zk
 
-local adapter = {}
+local M = {}
 
-function adapter.new()
-  -- zk_util.command {
-  --   "ZkNew",
-  --   function()
-  --   end
-  -- }
-  zk_util.command {"ZkNew", [[<cmd>!zk new --title <q-args>]], nargs = 1}
-  local title = vim.fn.input("Enter new Zk note title: ")
-  if title and #title > 0 then
-    vim.cmd "redraw" -- clear the input message we just added
-    vim.cmd(string.format([[execute 'ZkNew %s']], title))
-  end
-  vim.cmd([[execute 'ZkNew']], title)
-  -- vim.api.nvim_set_keymap("n", "<leader>zn", "<cmd>ZkNew<CR>", {noremap = true, silent = false, expr = true})
+function M.new(args)
+  -- if args.title == nil then
+  --   vim.fn.system(string.format("zk new --title %s %s", args.title, args.content))
+  -- else
+  --   vim.fn.system(string.format("zk new --title %s %s", args.title, args.content))
+  -- end
 end
 
-function adapter.search()
+function M.search()
 end
 
-function adapter.backlink()
+function M.backlink()
 end
 
-return adapter
+return M

--- a/lua/zk/adapter.lua
+++ b/lua/zk/adapter.lua
@@ -16,26 +16,25 @@ function M.new(title)
         print(
           string.format("[zk.nvim] on_stdout -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
         )
-        if d == 0 then
-          vim.api.nvim_out_write("[zk.nvim] new zettel note created")
-          return
-        end
 
-        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+        vim.api.nvim_out_write("[zk.nvim] new zettel note created")
+        return
       end,
       on_stderr = function(j, d, e)
         print(
           string.format("[zk.nvim] on_stderr -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e))
         )
+
         if d == 0 then
           vim.api.nvim_out_write("[zk.nvim] new zettel note created")
           return
         end
 
-        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note")
+        vim.api.nvim_err_writeln("[zk.nvim] failed to create new zettel note -> " .. d[1])
       end,
       on_exit = function(j, d, e)
         print(string.format("[zk.nvim] on_exit -> j: %s, d: %s, e: %s", vim.inspect(j), vim.inspect(d), vim.inspect(e)))
+
         if d == 0 then
           vim.api.nvim_out_write("[zk.nvim] new zettel note created")
           return

--- a/lua/zk/command.lua
+++ b/lua/zk/command.lua
@@ -1,6 +1,6 @@
 -- The interface to provide the available commands via lua to nvim
 
-local adapter = require('zk.adapter')
+local adapter = require("zk.adapter")
 
 local M = {}
 
@@ -8,15 +8,18 @@ local zk_repo_path = "github.com/mickael-menu/zk"
 
 local function call_go_cmd()
   local cmd = {"go", "get", "-u", zk_repo_path}
-  vim.fn.jobstart(cmd, {
-    on_exit = function(_, d, _)
-      if d == 0 then
-        vim.api.nvim_out_write("[zk.nvim] latest zk installed")
-        return
+  vim.fn.jobstart(
+    cmd,
+    {
+      on_exit = function(_, d, _)
+        if d == 0 then
+          vim.api.nvim_out_write("[zk.nvim] latest zk installed")
+          return
+        end
+        vim.api.nvim_err_writeln("[zk.nvim] failed to install zk")
       end
-      vim.api.nvim_err_writeln("[zk.nvim] failed to install zk")
-    end,
-  })
+    }
+  )
 end
 
 function M.install_zk()
@@ -25,8 +28,7 @@ function M.install_zk()
   end
 
   if vim.fn.executable("zk") == 1 then
-    local answer = vim.fn.input(
-                     "[zk.nvim] latest zk already installed, do you want update? Y/n -> ")
+    local answer = vim.fn.input("[zk.nvim] latest zk already installed, do you want update? Y/n -> ")
     answer = string.lower(answer)
     while answer ~= "y" and answer ~= "n" do
       answer = vim.fn.input("[zk.nvim] please answer Y or n -> ")
@@ -35,6 +37,8 @@ function M.install_zk()
 
     if answer == "n" then
       vim.api.nvim_out_write("\n")
+      vim.cmd([[redraw]])
+
       return
     end
 

--- a/lua/zk/command.lua
+++ b/lua/zk/command.lua
@@ -1,25 +1,53 @@
 -- The interface to provide the available commands via lua to nvim
 
-local command = {}
 local adapter = require('zk.adapter')
 
-local subcommands = {
-  new = adapter.new,
-  search = adapter.search,
-  backlink = adapter.backlink
-}
+local M = {}
 
-function command.command_list()
-  return vim.tbl_keys(subcommands)
+local zk_repo_path = "github.com/mickael-menu/zk"
+
+local function call_go_cmd()
+  local cmd = {"go", "get", "-u", zk_repo_path}
+  vim.fn.jobstart(cmd, {
+    on_exit = function(_, d, _)
+      if d == 0 then
+        vim.api.nvim_out_write("[zk.nvim] latest zk installed")
+        return
+      end
+      vim.api.nvim_err_writeln("[zk.nvim] failed to install zk")
+    end,
+  })
 end
 
-function command.load_command(cmd,...)
-  local args = {...}
-  if next(args) ~= nil then
-    subcommands[cmd](args[1])
-  else
-    subcommands[cmd]()
+function M.install_zk()
+  if not vim.fn.executable("go") == 0 then
+    vim.api.nvim_err_writeln("[zk.nvim] golang not installed. It must be installed before continuing.")
   end
+
+  if vim.fn.executable("zk") == 1 then
+    local answer = vim.fn.input(
+                     "[zk.nvim] latest zk already installed, do you want update? Y/n -> ")
+    answer = string.lower(answer)
+    while answer ~= "y" and answer ~= "n" do
+      answer = vim.fn.input("[zk.nvim] please answer Y or n -> ")
+      answer = string.lower(answer)
+    end
+
+    if answer == "n" then
+      vim.api.nvim_out_write("\n")
+      return
+    end
+    vim.api.nvim_out_write("[zk.nvim] updating zk..\n")
+  else
+    print("[zk.nvim] installing zk..")
+  end
+
+  call_go_cmd()
 end
 
-return command
+function M.new(args)
+  print(vim.inspect(args))
+  -- return adapter.new(args)
+end
+
+return M

--- a/lua/zk/command.lua
+++ b/lua/zk/command.lua
@@ -37,6 +37,7 @@ function M.install_zk()
       vim.api.nvim_out_write("\n")
       return
     end
+
     vim.api.nvim_out_write("[zk.nvim] updating zk..\n")
   else
     print("[zk.nvim] installing zk..")
@@ -45,9 +46,8 @@ function M.install_zk()
   call_go_cmd()
 end
 
-function M.new(args)
-  print(vim.inspect(args))
-  -- return adapter.new(args)
+function M.new(title)
+  return adapter.new(title)
 end
 
 return M

--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -1,3 +1,10 @@
+if not vim.fn.executable("zk") then
+  print("[zk.nvim] zk go binary must be installed.")
+  return
+end
+
+_G.zk_util = require("zk.util")
+
 local zk = {}
 
 zk.default_config = {}

--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -1,8 +1,35 @@
 _G.zk_util = require("zk.util")
 
 local M = {}
+M.default_config = {
+  debug = false,
+  root_target = ".zk",
+  default_notebook_path = ""
+}
 
-function M.init()
+local extend_config = function(opts)
+  opts = opts or {}
+  if next(opts) == nil then
+    return
+  end
+  for key, value in pairs(opts) do
+    if M.default_config[key] == nil then
+      error(string.format("[zk.nvim] The given key, %s, does not exist in config values", key))
+      return
+    end
+    if type(M.default_config[key]) == "table" then
+      for k, v in pairs(value) do
+        M.default_config[key][k] = v
+      end
+    else
+      M.default_config[key] = value
+    end
+  end
+end
+
+function M.init(opts)
+  extend_config(opts)
+
   vim.cmd("command! -nargs=? ZkNew :lua require('zk.command').new('<f-args>')")
   vim.cmd("command! ZkInstall :lua require('zk.command').install_zk()")
 

--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -30,6 +30,8 @@ local extend_config = function(opts)
 end
 
 function zk.init(opts)
+  print(string.format("loaded zk with opts: %s", opts))
+
   extend_config(opts)
 end
 

--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -1,38 +1,15 @@
-if not vim.fn.executable("zk") then
-  print("[zk.nvim] zk go binary must be installed.")
-  return
-end
-
 _G.zk_util = require("zk.util")
 
-local zk = {}
+local M = {}
 
-zk.default_config = {}
+function M.init()
+  vim.cmd("command! -nargs=? ZkNew :lua require('zk.command').new('<f-args>')")
+  vim.cmd("command! ZkInstall :lua require('zk.command').install_zk()")
 
-local extend_config = function(opts)
-  opts = opts or {}
-  if next(opts) == nil then
+  if vim.fn.executable("zk") == 0 then
+    vim.api.nvim_err_writeln("[zk.nvim] zk is not installed. Call :ZkInstall to install it")
     return
   end
-  for key, value in pairs(opts) do
-    if zk.default_config[key] == nil then
-      error(string.format("[Zk] Key %s does not exist in config values", key))
-      return
-    end
-    if type(zk.default_config[key]) == "table" then
-      for k, v in pairs(value) do
-        zk.default_config[key][k] = v
-      end
-    else
-      zk.default_config[key] = value
-    end
-  end
 end
 
-function zk.init(opts)
-  print(string.format("loaded zk with opts: %s", opts))
-
-  extend_config(opts)
-end
-
-return zk
+return M

--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -1,6 +1,7 @@
 _G.zk_util = require("zk.util")
 
 local M = {}
+
 M.default_config = {
   debug = false,
   root_target = ".zk",
@@ -27,7 +28,7 @@ local extend_config = function(opts)
   end
 end
 
-function M.init(opts)
+function M.setup(opts)
   extend_config(opts)
 
   vim.cmd("command! -nargs=? ZkNew :lua require('zk.command').new('<f-args>')")

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+-- TODO: once commands can take functions as arguments natively remove this global
+M.command_callbacks = {}
+
+function M.command(args)
+  local commands_table_name = "zk_util.command_callbacks"
+  local nargs = args.nargs or 0
+  local name = args[1]
+  local rhs = args[2]
+  local types = (args.types and type(args.types) == "table") and table.concat(args.types, " ") or ""
+
+  if type(rhs) == "function" then
+    table.insert(M.command_callbacks, rhs)
+    rhs = string.format("lua %s[%d](%s)", commands_table_name, #M.command_callbacks, nargs == 0 and "" or "<f-args>")
+  end
+
+  vim.cmd(string.format("command! -nargs=%s %s %s %s", nargs, types, name, rhs))
+end
+
+return M

--- a/plugin/zk.vim
+++ b/plugin/zk.vim
@@ -50,7 +50,7 @@ function! s:zk_complete(...)
 endfunction
 
 " Zk Commands with complete
-command! -nargs=+ -complete=custom,s:zk_complete Lspsaga    lua require('zk.command').load_command(<f-args>)
+command! -nargs=+ -complete=custom,s:zk_complete Zk    lua require('zk.command').load_command(<f-args>)
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/zk.vim
+++ b/plugin/zk.vim
@@ -50,7 +50,10 @@ function! s:zk_complete(...)
 endfunction
 
 " Zk Commands with complete
-command! -nargs=+ -complete=custom,s:zk_complete Zk    lua require('zk.command').load_command(<f-args>)
+command! -nargs=+ -complete=custom,s:zk_complete Zk lua require('zk.command').load_command(<f-args>)
+
+" command! -nargs=1 -complete=file PlenaryBustedFile
+"       \ lua require('plenary.busted').run(vim.fn.expand("<args>"))
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/zk.vim
+++ b/plugin/zk.vim
@@ -5,7 +5,7 @@ set cpo&vim
 
 if !has('nvim')
     echohl Error
-    echom "[zk.nvim] This plug presently only supports neovim versions: nightly, >=0.5.0"
+    echom "[zk.nvim] This plugin presently only supports neovim versions: nightly, >=0.5.0"
     echohl clear
     finish
 endif

--- a/plugin/zk.vim
+++ b/plugin/zk.vim
@@ -5,55 +5,14 @@ set cpo&vim
 
 if !has('nvim')
     echohl Error
-    echom "Sorry this plugin only works with versions of neovim that support lua: nightly, >=0.5.0"
+    echom "[zk.nvim] This plug presently only supports neovim versions: nightly, >=0.5.0"
     echohl clear
     finish
 endif
 
 let g:loaded_zk = 1
 
-highlight default ZkThing guifg=#89d957 guibg=NONE gui=bold
-highlight default link ZkStuff Normal
-
-" Zk builtin lists
-" function! s:zk_complete(arg,line,pos)
-"   let l:builtin_list = luaeval('vim.tbl_keys(require("telescope.builtin"))')
-"   " let l:extensions_list = luaeval('vim.tbl_keys(require("telescope._extensions").manager)')
-"   " let l:options_list = luaeval('vim.tbl_keys(require("telescope.config").values)')
-"   " let l:extensions_subcommand_dict = luaeval('require("telescope.command").get_extensions_subcommand()')
-
-"   let list = [extend(l:builtin_list,l:extensions_list),l:options_list]
-"   let l = split(a:line[:a:pos-1], '\%(\%(\%(^\|[^\\]\)\\\)\@<!\s\)\+', 1)
-"   let n = len(l) - index(l, 'Telescope') - 2
-
-"   if n == 0
-"     return join(list[0],"\n")
-"   endif
-
-"   if n == 1
-"     if index(l:extensions_list,l[1]) >= 0
-"       return join(get(l:extensions_subcommand_dict, l[1], []),"\n")
-"     endif
-"     return join(list[1],"\n")
-"   endif
-
-"   if n > 1
-"     return join(list[1],"\n")
-"   endif
-" endfunction
-
-" " Zk Commands with complete
-" command! -nargs=* -complete=custom,s:zk_complete Zk    lua require('zk.command').load_command(<f-args>)
-
-function! s:zk_complete(...)
-  return join(luaeval('require("zk.command").command_list()'),"\n")
-endfunction
-
-" Zk Commands with complete
-command! -nargs=+ -complete=custom,s:zk_complete Zk lua require('zk.command').load_command(<f-args>)
-
-" command! -nargs=1 -complete=file PlenaryBustedFile
-"       \ lua require('plenary.busted').run(vim.fn.expand("<args>"))
+lua require('zk').init()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/zk.vim
+++ b/plugin/zk.vim
@@ -12,7 +12,8 @@ endif
 
 let g:loaded_zk = 1
 
-lua require('zk').init()
+" NOTE: we require that the user runs setup themselves.."
+" lua require('zk').setup({})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This PR adds some additional structure and arch around future command creation and usage.

It first enables a way to install `zk` into the user's `GOPATH`. Secondly it enables a way to create a new `zk` note, this feature is presently broken (see #1) until we create a way to handle `zk`'s requirement to be run within a `cwd` that contains an initialized notebook using a `.zk` root marker.

See further discussion here: https://github.com/mickael-menu/zk/discussions/11#discussioncomment-489636