### PR TITLE
fix inability to set any options

### DIFF
--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -24,9 +24,9 @@ function M.setup_keymaps()
   end
 end
 
-function M.setup(opts)
-  opts = opts or {}
-  local config_values = {
+function M.setup(args)
+  args = args or {}
+  local defaults = {
     debug = false,
     log = true,
     default_keymaps = true,
@@ -35,7 +35,7 @@ function M.setup(opts)
     link_format = "markdown" -- or "wiki"
   }
 
-  _G.zk_config = util.extend(opts, config_values)
+  _G.zk_config = util.extend(defaults, args)
 
   vim.cmd([[command! ZkInstall :lua require('zk.command').install_zk()]])
 


### PR DESCRIPTION
The `util.extend` function was used backwards in the `setup()` function, so it was impossible to override any of the defaults. I don't *really* see why it was necessary to create a wrapper around `vim.tbl_extend("force", a, b)`. But I also changed the name of the setup function's argument to match all the other uses of `util.extend`.
