### PR TITLE
Add telescope support to search titles of notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ vim.api.nvim_set_keymap(
 )
 ```
 
+#### Telescope support
+
+Load the `zk` extension to enable `zk` support in `telescope`.
+
+```lua
+require('telescope').load_extension('zk')
+```
+
+Register a keymap to open the picker for the zk notes.
+
+```vim
+nnoremap <leader>n <cmd>lua require('telescope').extensions.zk.zk_notes()<cr>
+```
+
 ### Credit
 
 - Mickael Menu (https://github.com/mickael-menu/zk)

--- a/lua/telescope/_extensions/zk.lua
+++ b/lua/telescope/_extensions/zk.lua
@@ -1,0 +1,57 @@
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local actions = require("telescope.actions")
+local make_entry = require("telescope.make_entry")
+local action_set = require("telescope.actions.set")
+local action_state = require("telescope.actions.state")
+local conf = require("telescope.config").values
+
+local open_note = function(prompt_bufnr)
+    local selection = action_state.get_selected_entry(prompt_bufnr)
+    actions.close(prompt_bufnr)
+    vim.cmd(":edit " .. selection.filename)
+end
+
+local telescope_zk_notes = function(opts)
+    opts = opts or {}
+
+    local lookup_keys = {
+        display = 2,
+        ordinal = 1,
+        value = 1,
+        filename = 3,
+    }
+
+    local mt_string_entry = {
+        __index = function(t, k)
+            return rawget(t, rawget(lookup_keys, k))
+        end
+    }
+
+    -- TODO: can I use _G.zk_config here?
+    opts.entry_maker = function(line)
+        local tmp_table = vim.split(line, "\t");
+        return setmetatable({
+            line,
+            tmp_table[2],
+            _G.zk_config.default_notebook_path .. "/" .. tmp_table[1],
+        }, mt_string_entry)
+    end
+
+    pickers.new({}, {
+        prompt_title = "Zk notes",
+        finder = finders.new_oneshot_job(vim.tbl_flatten({ "zk", "list", "-q", "-P", "--format", "{{ path }}\t{{ title }}" }), opts),
+        sorter = conf.generic_sorter({}),
+        previewer = conf.file_previewer(opts),
+        attach_mappings = function(_, map)
+            action_set.select:replace(open_note)
+            return true
+        end
+    }):find()
+end
+
+return require("telescope").register_extension({
+    exports = {
+        zk_notes = telescope_zk_notes,
+    }
+})


### PR DESCRIPTION
This PR adds support for Telescope. An extension is added to show Telescope with the files from the current `zk`.

This is my first Lua extension for Neovim, so there could be some room for improvement.