### PR TITLE
ensure zk_config is not nil

### DIFF
--- a/lua/zk/init.lua
+++ b/lua/zk/init.lua
@@ -3,7 +3,7 @@ local util = require("zk.util")
 local M = {}
 
 function M.setup_keymaps()
-  if zk_config.default_keymaps and vim.bo.filetype == "markdown" then
+  if zk_config and zk_config.default_keymaps and vim.bo.filetype == "markdown" then
     -- FIXME: `<CR>` seems to break completion popups confirmation
     vim.api.nvim_set_keymap(
       "x",


### PR DESCRIPTION
Thanks for writing this interface to zk.

When I am lazy loading the plugin using dein; during vim initialising setup() is getting called after the setup_keymaps() which will error without a check on zk_config existing.

This ia causing errors on z new for me.
