### PR TITLE
Fixes full-pathing links and being able to linkify links

### DIFF
--- a/lua/zk/command.lua
+++ b/lua/zk/command.lua
@@ -93,6 +93,11 @@ function M.create_note_link(args)
     opts.title = selection.contents
   end
 
+  if util.is_linkified(opts.title) then
+      util.error('Attempting to linkify a link, ignoring.')
+      return
+  end
+
   print("create_note_link(title) -> ", opts.title)
 
   if opts.title ~= nil and opts.title ~= "" then

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -59,7 +59,7 @@ end
 function M.is_linkified(str)
   local current_line = vim.fn.getline(".")
   local patterns = {
-    "%[" .. str .. "%]"
+    "%[" .. str .. ".*%|?%]"
     -- string.format("%{%s%}", str)
   }
 
@@ -77,12 +77,14 @@ function M.make_link_text(title, path)
     return
   end
 
+  local relative_path = vim.fn.fnamemodify(path, ':.:gs?//?/?')
+
   if zk_config.link_format == "markdown" then
-    return string.format("[%s](%s)", title, vim.fn.shellescape(path))
+    return string.format("[%s](%s)", title, relative_path)
   elseif zk_config.link_format == "wiki" then
     -- TODO: look into supporting link | description:
     -- https://github.com/vimwiki/vimwiki/tree/dev#basic-markup
-    return string.format("[[%s|%s]]", vim.fn.shellescape(path), title)
+    return string.format("[[%s|%s]]", relative_path, title)
   end
 end
 


### PR DESCRIPTION
Resolves #39 and possibly #25

I don't think the regex considered WikiLinks (which is what I use) so this resolves that for the cases where `[[SomeID.md|someText]]` is trying to be linkified again.  Not foolproof but at least is a start.  Might be worth it honestly to wildcard before and after `str`.